### PR TITLE
chore: update evans version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ $(BIN)/protoc-gen-go:
 $(BIN)/protoc-gen-validate:
 	test -f $(BIN)/protoc-gen-validate || $(GO_ENV) go install github.com/envoyproxy/protoc-gen-validate@v0.6.0
 $(BIN)/evans:
-	test -f $(BIN)/evans || $(GO_ENV) go install github.com/ktr0731/evans@v0.10.6
+	test -f $(BIN)/evans || $(GO_ENV) go install github.com/ktr0731/evans@v0.10.9
 
 .PHONY: vendor
 vendor:


### PR DESCRIPTION
https://gincoinc.slack.com/archives/GH4B13RLK/p1661309906020369?thread_ts=1661300644.869769&cid=GH4B13RLK

github.com/ktr0731/evans@v0.10.8であったバグが修正されていました。
v0.10.9でローカルで起動可能なことを確認しました。