### PR TITLE
Fix: BNB, JOC postbox

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,14 @@ services:
     env_file:
       - "./envs/teller/.env"
   # postbox:
-  #   image: ginco/postbox:v0.32.0
+  #   image: ginco/postbox:v0.32.1
   #   command: -f /root/configs/config.toml
   #   volumes:
   #     - "./configs/postbox/config.toml:/root/configs/config.toml"
   #   env_file:
   #     - "./envs/postbox/.env"
   # postbox-gateway:
-  #   image: ginco/postbox-gateway:v0.32.0
+  #   image: ginco/postbox-gateway:v0.32.1
   #   ports:
   #     - "8080:8080"
   #   command: >


### PR DESCRIPTION
postboxを更新しました。

通貨Bと通貨Jの対応が入ったpostboxのバージョン
https://github.com/GincoInc/postbox/releases/tag/v0.32.1

出たエラー
```
gew-kmp-teller-1           | {"severity":"ERROR","timestamp":"2024-03-06T00:10:15.457235793Z","caller":"v1/main.go:295","message":"Webhook response status code is not 200: Webhook response status code is not 200","env":"dev","event":"aggregate_id:\"b78f8a75-d0ac-47c7-87e2-f319f3ea6e8d\"  event_id:\"26b44c1a-c43f-438a-881c-2e5a029e4810\"  event_type:\"EVENT_TRANSFER_UPDATED\"  payload:\"\\n$6cbe467b-81be-435b-876f-258bcbe1175e\\x12$f07d8ab0-0aee-4100-81f1-4da770ee11f7\\x1a$dc4260bb-52a1-4206-9efa-6a1547c3c2f1 ?*B0x4c6c42ba3d5ce969e2114f15c4703778c150f0412a8f0ff2f21faf6a1e0a92d19\\x9a\\x99\\x99\\x99\\x99\\x99\\xb9?B\\x140.100000000000000001I\\xc3\\xf5(\\\\7\\xd1\\xed@R*0x09BC85cD8a172F65F4049F5ef74a076506F9b558`\\x02h\\x01p\\x01\\x82\\x01*0xFAF8F0c1Af19c9a04895c8720574EAd4114e39BA\\x8a\\x01*0x09BC85cD8a172F65F4049F5ef74a076506F9b558\\x91\\x01a2U0*\\xa9S?\\x9a\\x01\\x060.0012\"  create_time:1709613309","logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"/go/src/tmp/cmd/v1/main.go","line":"295","function":"main.main.func3.1"}}
```


