### PR TITLE
Update: teller v2.78.8

### DIFF
--- a/docker-compose-internal.yml
+++ b/docker-compose-internal.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   teller:
-    image: ginco/teller:v2.78.7
+    image: ginco/teller:v2.78.8
     ports:
       - "50051:50051"
     command: -f /root/configs/config.toml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   teller:
-    image: ginco/teller:v2.78.7
+    image: ginco/teller:v2.78.8
     ports:
       - "50051:50051"
     command: -f /root/configs/config.toml


### PR DESCRIPTION
Bumps `ginco/teller` from v2.78.7 to v2.78.8 in both docker-compose.yml and docker-compose-internal.yml.